### PR TITLE
Fix some errors in early tutorials

### DIFF
--- a/learn/chapter1/2-hello-triangle.md
+++ b/learn/chapter1/2-hello-triangle.md
@@ -348,18 +348,20 @@ GL.VertexAttribPointer(0, 3, VertexAttribPointerType.Float, false, 3 * sizeof(fl
 GL.EnableVertexAttribArray(0);
 ```
 
-The function glVertexAttribPointer has quite a few parameters, so let's carefully walk through them:
+The function `GL.VertexAttribPointer` has quite a few parameters, so let's carefully walk through them:
 
-- The first parameter specifies which vertex attribute we want to configure. Remember that we specified the location of the position vertex attribute in the vertex shader with layout (location = 0). This sets the location of the vertex attribute to 0 and since we want to pass data to this vertex attribute, we pass in 0.
+- The first parameter specifies which vertex attribute we want to configure. Remember that we specified the location of the position vertex attribute in the vertex shader with `layout (location = 0)`. This sets the location of the vertex attribute to 0 and since we want to pass data to this vertex attribute, we pass in 0.
 - The next argument specifies the size of the vertex attribute. The vertex attribute is a vec3 so it is composed of 3 values.
-- The third argument specifies the type of the data which is GL_FLOAT (a vec* in GLSL consists of floating point values).
-- The next argument specifies if we want the data to be normalized. If we're inputting integer data types (int, byte) and we've set this to GL_TRUE, the integer data is normalized to 0 (or -1 for signed data) and 1 when converted to float. This is not relevant for us so we'll leave this as false.
+- The third argument specifies the type of the data, which is `float` (a vec* in GLSL consists of floating point values).
+- The next argument specifies if we want the data to be normalized. If we're inputting integer data types (int, byte) and we've set this to GL_TRUE, the integer data is normalized to 0 (or -1 for signed data) and 1 when converted to float. This is not relevant for us, so we'll leave this as false.
 - The fifth argument is known as the stride and tells us the space between consecutive vertex attributes. Since the next set of position data is located exactly 3 times the size of a float away we specify that value as the stride. Note that since we know that the array is tightly packed (there is no space between the next vertex attribute value) we could've also specified the stride as 0 to let OpenGL determine the stride (this only works when values are tightly packed). Whenever we have more vertex attributes we have to carefully define the spacing between each vertex attribute but we'll get to see more examples of that later on.
 - The last parameter is the offset of where the position data begins in the buffer. Since the position data is at the start of the data array this value is just 0. We will explore this parameter in more detail later on
 
-Each vertex attribute takes its data from memory managed by a VBO and which VBO it takes its data from (you can have multiple VBOs) is determined by the VBO currently bound to GL_ARRAY_BUFFER when calling glVertexAttribPointer. Since the previously defined VBO is still bound before calling glVertexAttribPointer vertex attribute 0 is now associated with its vertex data.
+Each vertex attribute takes its data from memory managed by a VBO and which VBO it takes its data from (you can have multiple VBOs) is determined by the VBO currently bound to `ArrayBuffer` when calling `GL.VertexAttribPointer`. Since the previously defined VBO is still bound before calling glVertexAttribPointer vertex attribute 0 is now associated with its vertex data.
 
-Now that we specified how OpenGL should interpret the vertex data we should also enable the vertex attribute with glEnableVertexAttribArray giving the vertex attribute location as its argument; vertex attributes are disabled by default. From that point on we have everything set up: we initialized the vertex data in a buffer using a vertex buffer object, set up a vertex and fragment shader and told OpenGL how to link the vertex data to the vertex shader's vertex attributes. Drawing an object in OpenGL would now look something like this:
+Now that we specified how OpenGL should interpret the vertex data we should also enable the vertex attribute with `GL.EnableVertexAttribArray` giving the vertex attribute location as its argument; vertex attributes are disabled by default.
+
+From that point on we have everything set up: we initialized the vertex data in a buffer using a vertex buffer object, set up a vertex and fragment shader and told OpenGL how to link the vertex data to the vertex shader's vertex attributes. Drawing an object in OpenGL would now look something like this:
 
 ```cs
 GL.BindBuffer(BufferTarget.ArrayBuffer, VertexBufferObject);

--- a/learn/chapter1/2-hello-triangle.md
+++ b/learn/chapter1/2-hello-triangle.md
@@ -45,7 +45,7 @@ It's also here that we get our first OpenGL function call: `GL.ClearColor`. This
 Next, we have OnRenderFrame.
 
 ```cs
-protected override void OnRenderFrame(EventArgs e)
+protected override void OnRenderFrame(FrameEventArgs e)
 {
     GL.Clear(ClearBufferMask.ColorBufferBit);
 


### PR DESCRIPTION
Blue#9999 on Discord has pointed out a few issues with the tutorials, which this PR will fix.

- Incorrect type name in OnRenderFrame.
- C++ code in Hello Triangle
- Explanation of `GL.EnableVertexAttribArray` is squished into another paragraph and easy to miss