### PR TITLE
1-3 Review Fixes

### DIFF
--- a/learn/chapter1/0-opengl.md
+++ b/learn/chapter1/0-opengl.md
@@ -20,6 +20,7 @@ When using OpenGL's core-profile, OpenGL forces us to use modern practices. When
 This is also the reason why our tutorials are geared at Core-Profile OpenGL version 3.3. Although it is more difficult, it is greatly worth the effort.
 
 As of today, much higher versions of OpenGL are published (at the time of writing 4.5) at which you might ask: why do I want to learn OpenGL 3.3 when OpenGL 4.5 is out? The answer to that question is relatively simple. All future versions of OpenGL starting from 3.3 basically add extra useful features to OpenGL without changing OpenGL's core mechanics; the newer versions just introduce slightly more efficient or more useful ways to accomplish the same tasks. The result is that all concepts and techniques remain the same over the modern OpenGL versions so it is perfectly valid to learn OpenGL 3.3. Whenever you're ready and/or more experienced you can easily use specific functionality from more recent OpenGL versions.
+
 When using functionality from the most recent version of OpenGL, only the most modern graphics cards will be able to run your application. This is often why most developers generally target lower versions of OpenGL and optionally enable higher version functionality.
 
 In some tutorials you'll sometimes find more modern features which are noted down as such.
@@ -41,7 +42,7 @@ else
 }
 ```
 
-With OpenGL version 3.3 we rarely need an extension for most techniques, but wherever it is necessary proper instructions are provided.
+With OpenGL version 3.3, we rarely need an extension for most techniques, but wherever it is necessary proper instructions are provided.
 
 ## State machine
 

--- a/learn/chapter1/1-creating-a-window.md
+++ b/learn/chapter1/1-creating-a-window.md
@@ -43,7 +43,7 @@ Now we have a blank class. Time to turn it into a `GameWindow`. To do that, simp
 public class Game : GameWindow
 ```
 
-Now your class is operable as a basic window. This is good, but this limits you customizations. There are plenty of ways you can customize your `GameWindow`, but in this tutorial we're going to create a simple constructor to let us set the width, height, and title of the window. We do this by overriding a `base` constructor included with OpenTK:
+Now your class is a basic window. This is good, but by itself, you can't do anything with it. There are plenty of ways you can customize your `GameWindow`, but in this tutorial we're going to create a simple constructor to let us set the width, height, and title of the window. We do this by overriding a `base` constructor included with OpenTK:
 
 ```cs
 public Game(int width, int height, string title) : base(width, height, GraphicsMode.Default, title) { }
@@ -65,9 +65,9 @@ using (Game game = new Game(800, 600, "LearnOpenTK"))
 }
 ```
 
-Plug that code into your `Main` function, and go ahead and build & run your program! You now have a blank window, great job! However, the only way you can close your window is by using the cross (`X`) button or Alt+F4. We don't want that, Let's do a little bit of input handling!
+Plug that code into your `Main` function, then build and run your program! You now have a blank window, great job! However, the only way you can close your window is by using the cross (`X`) button or Alt+F4. We don't want that, Let's do a little bit of input handling!
 
-`GameWindow` has plenty of methods that you can override to add all sorts of functionality to your game. You can look at the "API" section of this website to look at them all, but in this case the one we're interested in is `OnUpdateFrame`.
+`GameWindow` has plenty of methods that you can override to add all sorts of functionality to your window. You can look at the "API" section of this website to look at them all, but in this case the one we're interested in is `OnUpdateFrame`.
 
 By just typing `override OnUpdateFrame` your IDE should be able to generate a function like this one:
 

--- a/learn/chapter1/1-creating-a-window.md
+++ b/learn/chapter1/1-creating-a-window.md
@@ -49,7 +49,7 @@ Now your class is a basic window. This is good, but by itself, you can't do anyt
 public Game(int width, int height, string title) : base(width, height, GraphicsMode.Default, title) { }
 ```
 
-Your `GameWindow` is ready to go! Now all you have to do is invoke it from your program. You should've had a Program.cs automatically created when you made the program earlier in the tutorial, as well as a `Main` function. To open your window when the program starts, we must:
+Your `GameWindow` is ready to go! Now all you have to do is create an instance of it in your program. When you created your project earlier, it should have also created a file named `Program.cs`, containing a `Main` function. To open your window when the program starts, we must:
 
 - Create an instance of your `Game` class
 - Start all the pumps by calling the `Run` function

--- a/learn/chapter1/3-element-buffer-objects.md
+++ b/learn/chapter1/3-element-buffer-objects.md
@@ -38,7 +38,7 @@ GL.BindBuffer(BufferTarget.ElementArrayBuffer, ElementBufferObject);
 GL.BufferData(BufferTarget.ElementArrayBuffer, indices.Length * sizeof(uint), indices, BufferUsageHint.StaticDraw);
 ```
 
-It's almost exactly the same as how you use the VBO!
+It's almost exactly the same as how you use the VBO! Most of OpenGL's buffer types will follow this pattern: Create with `GL.GenBuffer()`, bind with `GL.BindBuffer`, and then use `GL.BufferData` to add data to it.
 
 The EBO is now ready to go. Down in OnRenderFrame, replace the call to `DrawArrays` with the following:
 


### PR DESCRIPTION
Fixes for the issues Perksey mentioned in his review.

- Remove use of raw GL enum names in 2 and 3 (GL\_ARRAY\_BUFFER, for instance)

- Fix grammar in a few locations.

- Also add a few newlines and commas where they probably should have been to begin with.

- Add some more explanations in a few places

- Single lines of code now have their own code blocks, for syntax highlighting.