### PR TITLE
update ImageSharp code example to current API

### DIFF
--- a/learn/chapter1/4-textures.md
+++ b/learn/chapter1/4-textures.md
@@ -132,7 +132,6 @@ using System.Collections.Generic;
 using OpenTK.Graphics.OpenGL4;
 
 using SixLabors.ImageSharp;
-using SixLabors.ImageSharp.Advanced;
 using SixLabors.ImageSharp.PixelFormats;
 using SixLabors.ImageSharp.Processing;
 ```
@@ -147,24 +146,24 @@ Next, we'll have to use ImageSharp to load an image, and send those pixels to Op
 
 ```cs
 //Load the image
-Image<Rgba32> image = Image.Load(path);
+Image<Rgba32> image = Image.Load<Rgba32>(path);
 
 //ImageSharp loads from the top-left pixel, whereas OpenGL loads from the bottom-left, causing the texture to be flipped vertically.
 //This will correct that, making the texture display properly.
 image.Mutate(x => x.Flip(FlipMode.Vertical));
 
-//Get an array of the pixels, in ImageSharp's internal format.
-Rgba32[] tempPixels = image.GetPixelSpan().ToArray();
-
 //Convert ImageSharp's format into a byte array, so we can use it with OpenGL.
-List<byte> pixels = new List<byte>();
+var pixels = new List<byte>(4 * image.Width * image.Height);
 
-foreach (Rgba32 p in tempPixels)
-{
-    pixels.Add(p.R);
-    pixels.Add(p.G);
-    pixels.Add(p.B);
-    pixels.Add(p.A);
+for (int y = 0; y < image.Height; y++) {
+	var row = image.GetPixelRowSpan(y);
+
+	for (int x = 0; x < image.Width; x++) {
+		pixels.Add(row[x].R);
+		pixels.Add(row[x].G);
+		pixels.Add(row[x].B);
+		pixels.Add(row[x].A);
+	}
 }
 ```
 


### PR DESCRIPTION
The API of ImageSharp changed a bit and the code example that uses ImageSharp is now outdated.
This fixes this document.

Related also to [this issue](https://github.com/opentk/LearnOpenTK/issues/39) in a different repo