### PR TITLE
Fixed _UpdateMetadata.cmd script, and updated opentk submodule.

### DIFF
--- a/_UpdateMetadata.cmd
+++ b/_UpdateMetadata.cmd
@@ -1,4 +1,4 @@
 cd opentk
 git pull
 cd ..
-rebuildMetadata.cmd
+_RebuildMetadata.cmd


### PR DESCRIPTION
The `opentk` submodule was previously at `HEAD detached at 0a5c346c5` and now it's up to date with `master`.