### PR TITLE
Adding information about OpenGL debug callbacks and other related features.

### DIFF
--- a/learn/appendix_opengl/debug_callback.md
+++ b/learn/appendix_opengl/debug_callback.md
@@ -1,5 +1,5 @@
-Debug Callback, Messages and Object Labels
-==========================================
+Debug Callback
+==============
 OpenGL didn't have a comprehensive error notification system at its inception.
 The programmer was limited to querying `glError()` after commands, and the
 information provided in the return value was nothing more than the code for the
@@ -18,9 +18,6 @@ as the extension [`ARB_debug_output`](https://registry.khronos.org/OpenGL/extens
 "Specification document for KHR_debug."). This article covers usage of
 both `ARB_debug_output` extension and the 4.3+ API. `KHR_debug` however covers
 so much more than what was introduced in the original extension.
-
-Registering a Debug Callback
-----------------------------
 
 Firstly, you should create a function which will execute when OpenGL has
 debugging information to relay to your program.
@@ -68,12 +65,6 @@ private static void OnDebugMessage(
 > associated with them. If your debugger does not support mixed-mode debugging
 > it may affect your user experience if an exception is thrown or occurs within
 > the callback.
-
-> [!CAUTION]
-> The pointer `pMessage` is a a reference to memory you do not own. Attempts to
-> write to or accessing it outside the scope of the function can and will cause
-> an access violation. However, it is safe to use the string copied by the
-> `Marshal` class.
 
 Then you should create a delegate which encapsulates the function you just
 implmented.
@@ -134,10 +125,13 @@ GL.Enable(EnableCap.DebugOutputSynchronous)
 <br/>
 
 > [!TIP]
-> Using synchronous output may decrease your performance (untested) as OpenGL
+> Using synchronous output may decrease your performance significantly as OpenGL
 > will only call your function from the thread that the context is owned by.
-> Otherwise the graphics driver is allowed to call the function from any thread
-> concurrently. Be careful of the usual pitfalls of multithreading.
+> However, this will allow you to easily break in the callback function to
+> analyze the situtaion, such as viewing the stack trace and finding the culprit
+> code. Otherwise the graphics driver is allowed to call the function from any
+> thread concurrently. Be careful of the usual pitfalls of multithreading when
+> disabled.
 
 > [!NOTE]
 > The second paramter of `DebugMessageCallback*` determines the value of the

--- a/learn/appendix_opengl/debug_callback.md
+++ b/learn/appendix_opengl/debug_callback.md
@@ -1,0 +1,157 @@
+Debug Callback, Messages and Object Labels
+==========================================
+OpenGL didn't have a comprehensive error notification system at its inception.
+The programmer was limited to querying `glError()` after commands, and the
+information provided in the return value was nothing more than the code for the
+error. However since then, OpenGL has introduced the ability for programmers to
+register a callback function which delivers crucial debugging messages like
+errors and warnings to your code.
+
+The history of the debug callback dates to OpenGL 3.0, where AMD created the
+vendor specific extension [`AMD_debug_output`][AMD_debug_output] providing this
+functionality. This extensions was later approved by the OpenGL Architecture
+Review Board (ARB) as the extension [`ARB_debug_output`][ARB_debug_output] in
+2010\. Finally, since OpenGL 4.3, the extension is a core part of the API, as
+well as the extension [`KHR_debug`][KHR_debug]. This article covers usage of
+both `ARB_debug_output` extension and the 4.3+ API. `KHR_debug` however covers
+so much more than what was introduced in the original extension.
+
+Registering a Debug Callback
+----------------------------
+
+Firstly, you should create a function which will execute when OpenGL has
+debugging information to relay to your program.
+
+# [Base GL/KHR_debug/ARB_debug_output](#tab)
+```cs
+using System;
+using System.Runtime.InteropServices;
+using OpenTK.Graphics.OpenGL4; // Or alternatively OpenTK.Graphics.OpenGL
+
+// ...
+
+private static void OnDebugMessage(
+    DebugSource source,     // Source of the debugging message.
+    DebugType type,         // Type of the debugging message.
+    int id,                 // ID associated with the message.
+    DebugSeverity severity, // Severity of the message.
+    int length,             // Length of the string in pMessage.
+    IntPtr pMessage,        // Pointer to message string.
+    IntPtr pUserParam)      // The pointer you gave to OpenGL, explained later.
+{
+    // In order to access the string pointed to by pMessage, you can use Marshal
+    // class to copy its contents to a C# string without unsafe code. You can
+    // also use the new function Marshal.PtrToStringUTF8 since .NET Core 1.1.
+    string message = Marshal.PtrToStringAnsi(pMessage, length);
+
+    // The rest of the function is up to you to implement, however a debug output
+    // is always useful.
+    Console.WriteLine("[{0} source={1} type={2} id={3}] {4}", severity, source, type, id, message);
+
+    // Potentially, you may want to throw from the function for certain severity
+    // messages.
+    if (type == DebugType.DebugTypeError)
+    {
+        throw new Exception(message);
+    }
+}
+```
+***
+
+> [!NOTE] Neither the access modifier or whether the method is an instance method
+> or a static method matters.
+
+> [!WARNING]
+> This function is called from native code, which means there are stack frames
+> associated with them. If your debugger does not support mixed-mode debugging
+> it may affect your user experience if an exception is thrown or occurs within
+> the callback.
+
+> [!CAUTION]
+> The pointer `pMessage` is a a reference to memory you do not own. Attempts to
+> write to or accessing it outside the scope of the function can and will cause
+> an access violation. However, it is safe to use the string copied by the
+> `Marshal` class.
+
+Then you should create a delegate which encapsulates the function you just
+implmented.
+# [Base](#tab/onload-gl)
+```cs
+private static GLDebugProc DebugMessageDelegate = OnDebugMessage;
+```
+# [KHR_debug](#tab/onload-arb)
+```cs
+private static GLDebugProcKHR DebugMessageDelegate = OnDebugMessage;
+```
+# [ARB_debug_output](#tab/onload-arb)
+```cs
+private static GLDebugProcARB DebugMessageDelegate = OnDebugMessage;
+```
+***
+> [!NOTE]
+> Creating this reference is critical. A delegate is managed by the .NET garbage
+> collector, however, this delegate will be passed to a native function as a
+> pointer. The garbage collector cannot track outside references, and if there
+> are no references to the delegate, the pointer passed to the native function
+> becomes "dangling" (in simpler terms, invalid). This causes an access violation
+> whenever OpenGL attempts to call you back.
+>
+> And as before, access modifiers and instance/static do not matter as long as it
+> suits your code.
+
+Finally you can provide OpenGL your delegate as your debug callback. You can now
+enable debug output, and optionally enable synchronous output.
+
+# [Base](#tab/onload-gl)
+```cs
+GL.DebugMessageCallback(DebugMessageDelegate, IntPtr.Zero);
+GL.Enable(EnableCap.DebugOutput);
+
+// Optionally
+GL.Enable(EnableCap.DebugOutputSynchronous)
+```
+# [KHR_debug](#tab/onload-khr)
+```cs
+GL.Khr.DebugMessageCallback(DebugMessageDelegate, IntPtr.Zero);
+GL.Enable(EnableCap.DebugOutput);
+
+// Optionally
+GL.Enable(EnableCap.DebugOutputSynchronous)
+```
+# [ARB_debug_output]
+```cs
+GL.Arb.DebugMessageCallback(DebugMessageDelegate, IntPtr.Zero);
+GL.Enable(EnableCap.DebugOutput);
+
+// Optionally
+GL.Enable(EnableCap.DebugOutputSynchronous)
+```
+***
+> [!TIP] Using synchronous output may decrease your performance (untested)
+> as OpenGL will only call your function from the thread that the context is
+> owned by. Otherwise the graphics driver is allowed to call the function from
+> any thread concurrently. Be careful of the usual pitfalls of multithreading.
+
+> [!NOTE]
+> The second paramter of `DebugMessageCallback*` determines the value of the
+> `pUserParam` parameter in the callback. This parameter is designed for C users
+> which has no concept delegates, but only function pointers (before C23). If you
+> are very interested in using this parameter (instead of capturing objects via
+> the delegate as recommended) you can use any C# pointer, or a pointer to a C#
+> [GCHandle]. Common pointer gotchas apply.
+
+References
+----------
+ * This page is based on the [gist of Vassalware][vassalware_gist] on the topic.
+ * [AMD_debug_output]
+ * [ARB_debug_output]
+ * [KHR_debug]
+ * [System.Runtime.InteropServices.Marshal][Marshal]
+ * [System.Runtime.InteropServices.GCHandle][GCHandle]
+
+[AMD_debug_output]: <https://registry.khronos.org/OpenGL/extensions/AMD/AMD_debug_output.txt>   "Specification document for AMD_debug_output."
+[ARB_debug_output]: <https://registry.khronos.org/OpenGL/extensions/ARB/ARB_debug_output.txt>   "Specification document for ARB_debug_output."
+[KHR_debug]:        <https://registry.khronos.org/OpenGL/extensions/KHR/KHR_debug.txt>          "Specification document for KHR_debug."
+[vassalware_gist]:  <https://gist.github.com/Vassalware/d47ff5e60580caf2cbbf0f31aa20af5d>       "The original page this documentation is based on."
+[Marshal]: <https://learn.microsoft.com/en-us/dotnet/api/system.runtime.interopservices.marshal?view=net-6.0> "Reference page for System.Runtime.InteropServices.Marshal class."
+[GCHandle]: <https://learn.microsoft.com/en-us/dotnet/api/system.runtime.interopservices.gchandle?view=net-7.0> "A structure which allows native code to reference a C# object."

--- a/learn/appendix_opengl/debug_callback.md
+++ b/learn/appendix_opengl/debug_callback.md
@@ -8,11 +8,14 @@ register a callback function which delivers crucial debugging messages like
 errors and warnings to your code.
 
 The history of the debug callback dates to OpenGL 3.0, where AMD created the
-vendor specific extension [`AMD_debug_output`][AMD_debug_output] providing this
-functionality. This extensions was later approved by the OpenGL Architecture
-Review Board (ARB) as the extension [`ARB_debug_output`][ARB_debug_output] in
-2010\. Finally, since OpenGL 4.3, the extension is a core part of the API, as
-well as the extension [`KHR_debug`][KHR_debug]. This article covers usage of
+vendor specific extension [`AMD_debug_output`](https://registry.khronos.org/OpenGL/extensions/AMD/AMD_debug_output.txt 
+"Specification document for AMD_debug_output.") providing this functionality.
+This extensions was later approved by the OpenGL Architecture Review Board (ARB)
+as the extension [`ARB_debug_output`](https://registry.khronos.org/OpenGL/extensions/ARB/ARB_debug_output.txt
+"Specification document for ARB_debug_output.") in 2010\. Finally, since OpenGL
+4.3, the extension is a core part of the API, as well as the extension
+[`KHR_debug`](https://registry.khronos.org/OpenGL/extensions/KHR/KHR_debug.txt
+"Specification document for KHR_debug."). This article covers usage of
 both `ARB_debug_output` extension and the 4.3+ API. `KHR_debug` however covers
 so much more than what was introduced in the original extension.
 
@@ -22,7 +25,6 @@ Registering a Debug Callback
 Firstly, you should create a function which will execute when OpenGL has
 debugging information to relay to your program.
 
-# [Base GL/KHR_debug/ARB_debug_output](#tab)
 ```cs
 using System;
 using System.Runtime.InteropServices;
@@ -56,10 +58,10 @@ private static void OnDebugMessage(
     }
 }
 ```
-***
 
-> [!NOTE] Neither the access modifier or whether the method is an instance method
-> or a static method matters.
+> [!NOTE]
+> Neither the access modifier or whether the method is an instance method or a
+> static method matters.
 
 > [!WARNING]
 > This function is called from native code, which means there are stack frames
@@ -75,19 +77,21 @@ private static void OnDebugMessage(
 
 Then you should create a delegate which encapsulates the function you just
 implmented.
-# [Base](#tab/onload-gl)
+# [Base](#tab/delegate-gl)
 ```cs
 private static GLDebugProc DebugMessageDelegate = OnDebugMessage;
 ```
-# [KHR_debug](#tab/onload-arb)
+# [KHR_debug](#tab/delegate-khr)
 ```cs
 private static GLDebugProcKHR DebugMessageDelegate = OnDebugMessage;
 ```
-# [ARB_debug_output](#tab/onload-arb)
+# [ARB_debug_output](#tab/delegate-arb)
 ```cs
 private static GLDebugProcARB DebugMessageDelegate = OnDebugMessage;
 ```
 ***
+<br/>
+
 > [!NOTE]
 > Creating this reference is critical. A delegate is managed by the .NET garbage
 > collector, however, this delegate will be passed to a native function as a
@@ -102,7 +106,7 @@ private static GLDebugProcARB DebugMessageDelegate = OnDebugMessage;
 Finally you can provide OpenGL your delegate as your debug callback. You can now
 enable debug output, and optionally enable synchronous output.
 
-# [Base](#tab/onload-gl)
+# [Base](#tab/enable-gl)
 ```cs
 GL.DebugMessageCallback(DebugMessageDelegate, IntPtr.Zero);
 GL.Enable(EnableCap.DebugOutput);
@@ -110,7 +114,7 @@ GL.Enable(EnableCap.DebugOutput);
 // Optionally
 GL.Enable(EnableCap.DebugOutputSynchronous)
 ```
-# [KHR_debug](#tab/onload-khr)
+# [KHR_debug](#tab/enable-khr)
 ```cs
 GL.Khr.DebugMessageCallback(DebugMessageDelegate, IntPtr.Zero);
 GL.Enable(EnableCap.DebugOutput);
@@ -118,7 +122,7 @@ GL.Enable(EnableCap.DebugOutput);
 // Optionally
 GL.Enable(EnableCap.DebugOutputSynchronous)
 ```
-# [ARB_debug_output]
+# [ARB_debug_output](#tab/enable-arb)
 ```cs
 GL.Arb.DebugMessageCallback(DebugMessageDelegate, IntPtr.Zero);
 GL.Enable(EnableCap.DebugOutput);
@@ -127,10 +131,13 @@ GL.Enable(EnableCap.DebugOutput);
 GL.Enable(EnableCap.DebugOutputSynchronous)
 ```
 ***
-> [!TIP] Using synchronous output may decrease your performance (untested)
-> as OpenGL will only call your function from the thread that the context is
-> owned by. Otherwise the graphics driver is allowed to call the function from
-> any thread concurrently. Be careful of the usual pitfalls of multithreading.
+<br/>
+
+> [!TIP]
+> Using synchronous output may decrease your performance (untested) as OpenGL
+> will only call your function from the thread that the context is owned by.
+> Otherwise the graphics driver is allowed to call the function from any thread
+> concurrently. Be careful of the usual pitfalls of multithreading.
 
 > [!NOTE]
 > The second paramter of `DebugMessageCallback*` determines the value of the
@@ -138,20 +145,14 @@ GL.Enable(EnableCap.DebugOutputSynchronous)
 > which has no concept delegates, but only function pointers (before C23). If you
 > are very interested in using this parameter (instead of capturing objects via
 > the delegate as recommended) you can use any C# pointer, or a pointer to a C#
-> [GCHandle]. Common pointer gotchas apply.
+> [GCHandle]((https://learn.microsoft.com/en-us/dotnet/api/system.runtime.interopservices.gchandle?view=net-7.0 "A structure which allows native code to reference a C# object.")).
+> Common pointer gotchas apply.
 
 References
 ----------
- * This page is based on the [gist of Vassalware][vassalware_gist] on the topic.
- * [AMD_debug_output]
- * [ARB_debug_output]
- * [KHR_debug]
- * [System.Runtime.InteropServices.Marshal][Marshal]
- * [System.Runtime.InteropServices.GCHandle][GCHandle]
-
-[AMD_debug_output]: <https://registry.khronos.org/OpenGL/extensions/AMD/AMD_debug_output.txt>   "Specification document for AMD_debug_output."
-[ARB_debug_output]: <https://registry.khronos.org/OpenGL/extensions/ARB/ARB_debug_output.txt>   "Specification document for ARB_debug_output."
-[KHR_debug]:        <https://registry.khronos.org/OpenGL/extensions/KHR/KHR_debug.txt>          "Specification document for KHR_debug."
-[vassalware_gist]:  <https://gist.github.com/Vassalware/d47ff5e60580caf2cbbf0f31aa20af5d>       "The original page this documentation is based on."
-[Marshal]: <https://learn.microsoft.com/en-us/dotnet/api/system.runtime.interopservices.marshal?view=net-6.0> "Reference page for System.Runtime.InteropServices.Marshal class."
-[GCHandle]: <https://learn.microsoft.com/en-us/dotnet/api/system.runtime.interopservices.gchandle?view=net-7.0> "A structure which allows native code to reference a C# object."
+ * This page is based on the [gist of Vassalware](https://gist.github.com/Vassalware/d47ff5e60580caf2cbbf0f31aa20af5d> "The original page this documentation is based on.") on the topic.
+ * [AMD_debug_output](https://registry.khronos.org/OpenGL/extensions/AMD/AMD_debug_output.txt "Specification document for AMD_debug_output.")
+ * [ARB_debug_output](https://registry.khronos.org/OpenGL/extensions/ARB/ARB_debug_output.txt "Specification document for ARB_debug_output.")
+ * [KHR_debug](https://registry.khronos.org/OpenGL/extensions/KHR/KHR_debug.txt "Specification document for KHR_debug.")
+ * [System.Runtime.InteropServices.Marshal](https://learn.microsoft.com/en-us/dotnet/api/system.runtime.interopservices.marshal?view=net-6.0 "Reference page for System.Runtime.InteropServices.Marshal class.")
+ * [System.Runtime.InteropServices.GCHandle](https://learn.microsoft.com/en-us/dotnet/api/system.runtime.interopservices.gchandle?view=net-7.0 "A structure which allows native code to reference a C# object.")

--- a/learn/appendix_opengl/debug_callback.md
+++ b/learn/appendix_opengl/debug_callback.md
@@ -145,7 +145,7 @@ GL.Enable(EnableCap.DebugOutputSynchronous)
 > which has no concept delegates, but only function pointers (before C23). If you
 > are very interested in using this parameter (instead of capturing objects via
 > the delegate as recommended) you can use any C# pointer, or a pointer to a C#
-> [GCHandle]((https://learn.microsoft.com/en-us/dotnet/api/system.runtime.interopservices.gchandle?view=net-7.0 "A structure which allows native code to reference a C# object.")).
+> [GCHandle](https://learn.microsoft.com/en-us/dotnet/api/system.runtime.interopservices.gchandle?view=net-7.0 "A structure which allows native code to reference a C# object.").
 > Common pointer gotchas apply.
 
 References

--- a/learn/toc.yml
+++ b/learn/toc.yml
@@ -38,3 +38,7 @@
       href: chapter2/5-light-casters.md
     - name: 2.6. Multiple Lights
       href: chapter2/6-multiple-lights.md
+- name: "Appendix: Misc. OpenGL"
+  items:
+    - name: Debug Callback, Messages, and Object Labels
+      href: appendix_opengl/debug_callback.md

--- a/learn/toc.yml
+++ b/learn/toc.yml
@@ -40,5 +40,5 @@
       href: chapter2/6-multiple-lights.md
 - name: "Appendix: Misc. OpenGL"
   items:
-    - name: Debug Callback, Messages, and Object Labels
+    - name: Debug Callback
       href: appendix_opengl/debug_callback.md


### PR DESCRIPTION
This PR simply adds an appendix to LearnOpenTK where I describe the OpenGL debugging functions, taking inspiration from Vassalware's gist linked in #support on discord. It covers the base functions and the `KHR_debug` and `ARB_debug_output` extensions. Looking the expand the tutorial with more functions available. 