### PR TITLE
Update 1-creating-a-window.md

### DIFF
--- a/learn/chapter1/1-creating-a-window.md
+++ b/learn/chapter1/1-creating-a-window.md
@@ -164,9 +164,8 @@ protected override void OnUpdateFrame(FrameEventArgs e)
 ```cs
 //Get the state of the keyboard this frame
 // 'KeyboardState' is a property of GameWindow
-KeyboardState input = KeyboardState;
 
-if (input.IsKeyDown(Keys.Escape))
+if (KeyboardState.IsKeyDown(Keys.Escape))
 {
     Close();
 }
@@ -179,9 +178,7 @@ protected override void OnUpdateFrame(FrameEventArgs e)
 {
     base.OnUpdateFrame(e);
 
-    KeyboardState input = KeyboardState;
-
-    if (input.IsKeyDown(Keys.Escape))
+    if (KeyboardState.IsKeyDown(Keys.Escape))
     {
         Close();
     }


### PR DESCRIPTION
KeyboardState has no public constructor when we're using OpenTK.Windowing.GraphicsLibraryFramework. Instead, the methods are static to the class.