### PR TITLE
Minor fixes to the article KHR_debug.

### DIFF
--- a/learn/appendix_opengl/KHR_debug.md
+++ b/learn/appendix_opengl/KHR_debug.md
@@ -116,6 +116,23 @@ void GL.ObjectPtrLabel(
 );
 ```
 
+> [!WARNING]
+> The `length` parameter for most of the functions given are intended for C
+> users and is in ASCII characters, not UTF-16 characters. This causes a small
+> disparity between the length of a string in C#, and it's length in bytes after
+> marshalling between UTF-16 and ASCII/UTF-8 characters.
+>
+> Although in some cases (particularly where only 7-bit ASCII characters are
+> used) the number of characters in the C# string and the number of characters
+> in the C string are going to match, the most appropriate way would be to
+> measure the length of the string in bytes using
+> `System.Text.Encoding.UTF8.GetByteCount()`. However, that still takes
+> significant time and effort, so you might just want to use `-1` instead.
+>
+> Using `-1` is allowed by the extension as the length of a string, where the
+> graphics driver will calculate the length of the null terminated C string
+> itself.
+
 _Here are a few examples of object labels in different OpenGL debugging
 software._
 
@@ -259,23 +276,6 @@ void GL.DebugMessageInsert(
     string message              /* The message to insert. */
 );
 ```
-
-> [!WARNING]
-> The `length` parameter for most of the functions given are intended for C
-> users and is in ASCII characters, not UTF-16 characters. This causes a small
-> disparity between the length of a string in C#, and it's length in bytes after
-> marshalling between UTF-16 and ASCII/UTF-8 characters.
->
-> Although in some cases (particularly where only 7-bit ASCII characters are
-> used) the number of characters in the C# string and the number of characters
-> in the C string are going to match, the most appropriate way would be to
-> measure the length of the string in bytes using
-> `System.Text.Encoding.UTF8.GetByteCount()`. However, that still takes
-> significant time and effort, so you might just want to use `-1` instead.
->
-> Using `-1` is allowed by the extension as the length of a string, where the
-> graphics driver will calculate the length of the null terminated C string
-> itself.
 
 ### `GL.GetDebugMessageLog()`
 In the absense of a debug message callback, this function can be used to

--- a/learn/appendix_opengl/KHR_debug.md
+++ b/learn/appendix_opengl/KHR_debug.md
@@ -320,5 +320,5 @@ int GL.GetDebugMessageLog(
 
 References
 ----------
-* [Debug Messages on Khronos MeadiaWiki](https://www.khronos.org/opengl/wiki/Debug_Output)
+* [Debug Messages on Khronos MediaWiki](https://www.khronos.org/opengl/wiki/Debug_Output)
 * [KHR_debug on Khronos Registry](https://registry.khronos.org/OpenGL/extensions/KHR/KHR_debug.txt)

--- a/learn/appendix_opengl/KHR_debug.md
+++ b/learn/appendix_opengl/KHR_debug.md
@@ -124,14 +124,11 @@ void GL.ObjectPtrLabel(
 >
 > Although in some cases (particularly where only 7-bit ASCII characters are
 > used) the number of characters in the C# string and the number of characters
-> in the C string are going to match, the most appropriate way would be to
-> measure the length of the string in bytes using
-> `System.Text.Encoding.UTF8.GetByteCount()`. However, that still takes
-> significant time and effort, so you might just want to use `-1` instead.
+> in the C string are going to match, it might not always be the case.
 >
 > Using `-1` is allowed by the extension as the length of a string, where the
 > graphics driver will calculate the length of the null terminated C string
-> itself.
+> itself. This applies for other functions in the extension too.
 
 _Here are a few examples of object labels in different OpenGL debugging
 software._


### PR DESCRIPTION
I was originally going to wait a bit to fix this typo, but I found a minor issue that didn't bode too well with me.

* Fix the typo in MediaWiki
* Move the warning about the length parameter to the appropriate place (again)
  - I accidentally moved further back when rearranging the headers.